### PR TITLE
Mudança do cPickle

### DIFF
--- a/classificador-cachorros-gatos-estimator/classificador-de-imagens-estimators.ipynb
+++ b/classificador-cachorros-gatos-estimator/classificador-de-imagens-estimators.ipynb
@@ -59,7 +59,7 @@
     "tf.logging.set_verbosity(tf.logging.INFO)  # Permitindo visualização de logs\n",
     "\n",
     "# Bibliotecas auxiliares\n",
-    "import cPickle  # maior eficiência ao processar as imagens\n",
+    "import _pickle as cPickle  # maior eficiência ao processar as imagens\n",
     "import numpy as np  # manipular vetores\n",
     "from PIL import Image  # lidar com imagens\n",
     "import matplotlib.pyplot as plt  # plotar imagens\n",


### PR DESCRIPTION
No python 3x o ``cPickle`` agr é importado como ``_pickle``.
Obs: Usei ``import _pickle as cPickle`` para n precisar alterar todos os ``cPickle`` do código